### PR TITLE
Transitionのアニメーションをsafariにも対応

### DIFF
--- a/components/atoms/transitions/ScaleTransition.vue
+++ b/components/atoms/transitions/ScaleTransition.vue
@@ -4,8 +4,8 @@
     :leave-to-class="$style.scaleLeaveTo"
     :enter-active-class="$style.scaleEnterActive"
     :leave-active-class="$style.scaleLeaveActive"
-    appear=""
     :duration="duration"
+    :appear="true"
     @before-enter="beforeEnter"
   >
     <slot v-if="!isExiting" />


### PR DESCRIPTION
## やったこと

safariでもcubic-bezierでネガティブ値が使えるようにしました。

## 注意点

## スクリーンショット（あれば）
